### PR TITLE
Fix canvas zoom resolution by using viewBox scaling instead of CSS tr…

### DIFF
--- a/src/frontend/src/components/Canvas.tsx
+++ b/src/frontend/src/components/Canvas.tsx
@@ -117,9 +117,10 @@ export default function Canvas() {
   // Track last click for double-click detection on canvas
   const lastCanvasClickRef = useRef<{ time: number; x: number; y: number } | null>(null)
 
-  // Calculate viewBox with pan offset
+  // Calculate viewBox with pan offset and zoom
+  // Zoom is applied via viewBox (not CSS transform) to maintain vector crispness at any zoom level
   const viewBox = calculateViewBox(flowchart.nodes)
-  const viewBoxStr = `${viewBox.x - panOffset.x} ${viewBox.y - panOffset.y} ${viewBox.width} ${viewBox.height}`
+  const viewBoxStr = `${viewBox.x - panOffset.x} ${viewBox.y - panOffset.y} ${viewBox.width / zoom} ${viewBox.height / zoom}`
 
   // Convert screen coords to SVG coords
   const screenToSVG = useCallback(
@@ -1193,8 +1194,6 @@ export default function Canvas() {
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           style={{
-            transform: `scale(${zoom})`,
-            transformOrigin: 'center',
             cursor: isPanning ? 'grabbing' : 'grab'
           }}
         >


### PR DESCRIPTION
…ansform

When zooming in, the canvas was becoming blurry/pixelated because zoom was applied as a CSS transform, which scales the rasterized SVG output.

Changed to apply zoom via viewBox dimensions instead, which keeps content as vectors at any zoom level, rendering crisp at the target resolution.

Changes:
- viewBox width/height now divided by zoom factor
- Removed CSS transform: scale() from SVG element