### PR TITLE
Add rate limiting to HTTP endpoints (60 req/min per IP)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ mcp==1.25.0
 # Frontend/backend runtime deps
 Flask==3.0.3
 flask-cors==4.0.1
+Flask-Limiter==3.5.0
 Flask-SocketIO==5.3.6
 eventlet==0.36.1
 gunicorn==22.0.0

--- a/src/backend/api/app.py
+++ b/src/backend/api/app.py
@@ -4,13 +4,24 @@ from __future__ import annotations
 
 from flask import Flask
 from flask_cors import CORS
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 
 from ..utils.logging import setup_logging
 from .common import cors_origins
+
+# Rate limiter instance - 60 requests/minute per IP for HTTP endpoints
+# Note: WebSocket traffic (chat, sync_workflow) is not affected by this limiter
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["60 per minute"],
+    storage_uri="memory://",
+)
 
 
 def create_app() -> Flask:
     setup_logging()
     app = Flask(__name__)
     CORS(app, supports_credentials=True, origins=cors_origins())
+    limiter.init_app(app)
     return app


### PR DESCRIPTION
Adds Flask-Limiter for HTTP API rate limiting. WebSocket traffic (chat, sync_workflow) is unaffected since most app communication uses Socket.IO.

Changes:
- requirements.txt: Added Flask-Limiter==3.5.0
- src/backend/api/app.py: Initialized limiter with 60/min default

Returns 429 Too Many Requests when limit exceeded.