### PR TITLE
Isolate chat history per workflow tab

### DIFF
--- a/src/frontend/src/stores/chatStore.ts
+++ b/src/frontend/src/stores/chatStore.ts
@@ -54,6 +54,10 @@ interface ChatState {
   // User message helper
   sendUserMessage: (content: string) => Message
 
+  // Snapshot: save/restore chat state when switching workflow tabs
+  getSnapshot: () => { conversationId: string | null; messages: Message[] }
+  restoreState: (conversationId: string | null, messages: Message[]) => void
+
   // Reset
   reset: () => void
 }
@@ -184,6 +188,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
     get().addMessage(message)
     return message
   },
+
+  // Snapshot: returns current chat state for saving into a workflow tab
+  getSnapshot: () => {
+    const state = get()
+    return { conversationId: state.conversationId, messages: state.messages }
+  },
+
+  // Restore: loads chat state from a workflow tab (single atomic update)
+  restoreState: (conversationId, messages) =>
+    set({
+      conversationId,
+      messages,
+      isStreaming: false,
+      streamingContent: '',
+      currentTaskId: null,
+      processingStatus: null,
+      pendingQuestion: null,
+      taskId: null,
+    }),
 
   // Reset
   reset: () =>

--- a/tests/test_conversation_isolation.py
+++ b/tests/test_conversation_isolation.py
@@ -1,0 +1,115 @@
+"""Tests for conversation isolation — each conversation_id gets independent state.
+
+Verifies that the ConversationStore creates separate orchestrator instances
+and workflow state per conversation_id, so different workflow tabs don't
+share chat history or workflow data.
+"""
+
+import pytest
+from pathlib import Path
+from src.backend.api.conversations import ConversationStore, Conversation
+
+
+class TestConversationIsolation:
+    """Verify that separate conversation_ids produce independent state."""
+
+    def setup_method(self):
+        self.store = ConversationStore(repo_root=Path("."))
+
+    def test_different_ids_create_separate_conversations(self):
+        """Two conversation_ids should produce distinct Conversation objects."""
+        convo_a = self.store.get_or_create("convo_a")
+        convo_b = self.store.get_or_create("convo_b")
+
+        assert convo_a.id == "convo_a"
+        assert convo_b.id == "convo_b"
+        assert convo_a is not convo_b
+
+    def test_same_id_returns_same_conversation(self):
+        """Requesting the same conversation_id should return the same object."""
+        convo_1 = self.store.get_or_create("convo_x")
+        convo_2 = self.store.get_or_create("convo_x")
+
+        assert convo_1 is convo_2
+
+    def test_separate_orchestrators_per_conversation(self):
+        """Each conversation should have its own orchestrator instance."""
+        convo_a = self.store.get_or_create("convo_a")
+        convo_b = self.store.get_or_create("convo_b")
+
+        assert convo_a.orchestrator is not convo_b.orchestrator
+
+    def test_workflow_state_isolated_between_conversations(self):
+        """Modifying workflow in conversation A should not affect conversation B."""
+        convo_a = self.store.get_or_create("convo_a")
+        convo_b = self.store.get_or_create("convo_b")
+
+        # Add nodes to conversation A
+        convo_a.update_workflow_state({
+            "nodes": [{"id": "n1", "type": "start", "label": "Begin", "x": 0, "y": 0}],
+            "edges": [],
+        })
+
+        # Conversation B should still have empty workflow
+        assert convo_b.workflow["nodes"] == []
+        assert convo_b.workflow["edges"] == []
+
+        # Conversation A should have the node
+        assert len(convo_a.workflow["nodes"]) == 1
+        assert convo_a.workflow["nodes"][0]["id"] == "n1"
+
+    def test_workflow_analysis_isolated_between_conversations(self):
+        """Modifying analysis in conversation A should not affect conversation B."""
+        convo_a = self.store.get_or_create("convo_a")
+        convo_b = self.store.get_or_create("convo_b")
+
+        # Add variables to conversation A's analysis
+        convo_a.update_workflow_analysis({
+            "variables": [{"id": "var_age_int", "name": "Age", "type": "int", "source": "input"}],
+            "outputs": [{"type": "string"}],
+        })
+
+        # Conversation B should have empty analysis
+        assert convo_b.workflow["inputs"] == []
+        assert convo_b.workflow["outputs"] == []
+
+        # Conversation A should have the variable
+        assert len(convo_a.workflow["inputs"]) == 1
+        assert convo_a.workflow["inputs"][0]["id"] == "var_age_int"
+
+    def test_orchestrator_message_history_isolated(self):
+        """Messages added to one orchestrator should not appear in another."""
+        convo_a = self.store.get_or_create("convo_a")
+        convo_b = self.store.get_or_create("convo_b")
+
+        # Add a message to conversation A's orchestrator history
+        convo_a.orchestrator.history.append({
+            "role": "user",
+            "content": "Build me a workflow for age checking",
+        })
+
+        # Conversation B's orchestrator should have no history
+        assert len(convo_b.orchestrator.history) == 0
+
+        # Conversation A should have the message
+        assert len(convo_a.orchestrator.history) == 1
+
+    def test_null_id_generates_unique_conversations(self):
+        """Passing None as conversation_id should create distinct conversations each time."""
+        convo_1 = self.store.get_or_create(None)
+        convo_2 = self.store.get_or_create(None)
+
+        assert convo_1.id != convo_2.id
+        assert convo_1 is not convo_2
+
+    def test_get_returns_none_for_unknown_id(self):
+        """get() should return None for a conversation_id that doesn't exist."""
+        result = self.store.get("nonexistent")
+        assert result is None
+
+    def test_get_returns_existing_conversation(self):
+        """get() should return the conversation if it exists."""
+        created = self.store.get_or_create("convo_z")
+        fetched = self.store.get("convo_z")
+
+        assert fetched is created


### PR DESCRIPTION
Each WorkflowTab now owns its own conversationId and messages. Switching tabs saves the outgoing chat state and restores the incoming tab's chat, so different workflows no longer share conversation history.